### PR TITLE
fix(ddev): auto-install orchestrate addon on pre-start

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -5,4 +5,4 @@ php_version: "8.4"
 hooks:
     pre-start:
         - exec-host: mkdir -p .ddev/wordpress
-        - exec-host: ddev add-on get apermo/ddev-orchestrate 2>/dev/null || true
+        - exec-host: test -d .ddev/addon-metadata/ddev-orchestrate || ddev add-on get apermo/ddev-orchestrate 2>/dev/null || true

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -5,3 +5,4 @@ php_version: "8.4"
 hooks:
     pre-start:
         - exec-host: mkdir -p .ddev/wordpress
+        - exec-host: ddev add-on get apermo/ddev-orchestrate 2>/dev/null || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WP-CLI commands for sites, plugins, themes, networks
 - E2E and unit test suites
 
+[0.1.3]: https://github.com/apermo/site-bookkeeper-dashboard/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/apermo/site-bookkeeper-dashboard/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/apermo/site-bookkeeper-dashboard/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/apermo/site-bookkeeper-dashboard/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- DDEV `pre-start` hook now installs the `apermo/ddev-orchestrate` addon
+  automatically, so `ddev orchestrate` works on fresh clones and in CI
+  without a manual `ddev add-on get` step
+
 ## [0.1.2] - 2026-04-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.3] - 2026-04-18
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

- Adds a second `pre-start` hook that runs `ddev add-on get apermo/ddev-orchestrate 2>/dev/null || true`, next to the existing `mkdir -p .ddev/wordpress` hook
- DDEV doesn't auto-restore addons from `.ddev/addon-metadata/`, so without this hook `ddev orchestrate` fails on fresh clones and in CI until someone runs the install command by hand. #23 has the full context
- The `2>/dev/null || true` suffix keeps the hook non-blocking when the addon is already installed or the runner can't reach the internet
- Unreleased CHANGELOG entry added

Closes #23.

Upstream tracker for the same fix in the template: apermo/template-wordpress#32.

## Test plan

- [ ] Fresh clone, no prior addon: `ddev start && ddev orchestrate` succeeds without a manual `ddev add-on get`
- [ ] Already-installed addon: `ddev restart` still succeeds — the hook is a no-op
- [ ] Offline run (no network): `ddev start` still succeeds because the hook tolerates failure