### PR TITLE
ci: bump actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,7 +13,7 @@ jobs:
         outputs:
             wp-versions: ${{ steps.versions.outputs.wp-versions }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - id: versions
               run: |
                   min=""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-06-08
+
+### Changed
+
+- Bump GitHub Actions off the deprecated Node 20 runtime: `actions/checkout`
+  v4→v5. GitHub forces JavaScript actions onto Node 24 starting 2026-06-16.
+
 ## [0.1.3] - 2026-04-18
 
 ### Fixed


### PR DESCRIPTION
## Background

GitHub forces JavaScript actions off the deprecated Node 20 runtime starting **2026-06-16**, with full removal on 2026-09-16.

## Changes

- `actions/checkout` v4→v5

This repo pins an older `reusable-pr-validation` (`@v0.4.x`) that requires a new version heading, so the bump is released as a patch (`0.1.4`). Consider updating the reusable-workflows pin to `@main` separately.

Closes #31